### PR TITLE
Allow extra fields in composer file

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The minimum required version for PHP
 ### magento_connect php_max
 The maximum support version of PHP
 
-### mmagento_connect stability
+### magento_connect stability
 Please use some key from [http://getcomposer.org/doc/04-schema.md#minimum-stability]
 
 ### magento_connect content

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Example
         ],
         "extra":{
             "magento_connect":{
+                "license_uri":"http://www.gnu.org/licenses/gpl-3.0.html",
+                "summary":"",
                 "channel":"community",
                 "php_min":"5.3.0",
                 "php_max":"6.0.0",
@@ -78,16 +80,22 @@ If you would like to install extensions via [composer magento installer](https:/
 you should use `magento-module`. The packager ignore this property.
 
 ### license
-Please use some key from [http://www.spdx.org/licenses/].
+The name of the license the package is covered by. Will also be used as a key from [http://www.spdx.org/licenses/], if an explicit URI is not provided in the `magento_connect` options.
 
 ### description
-A detailed description of you module. It will be used as description and summery.
+A detailed description of you module. It will be used as description and the summary, if an explicit summary is not provided in the `magento_connect` options.
 
 ### homepage
 Nothing more to say
 
 ### authors
 Who developed the module
+
+### magento_connect license_uri
+URI for a copy of the license text. If no value is provided the URI will default to using the value of `license` as a key from [http://www.spdx.org/licenses/].
+
+### magento_connect summary
+A brief summary of your module. If no value is provided then the `description` will be used.
 
 ### magento_connect channel
 Which channel should be used in magento connect.

--- a/src/shell/packager.php
+++ b/src/shell/packager.php
@@ -62,7 +62,7 @@ class Mage_Shell_Packager extends Mage_Shell_Abstract
                 $this->getConfig()->setData('channel', $this->getChannel());
                 $this->getConfig()->setData('license', $this->getLicense());
                 $this->getConfig()->setData('license_uri', $this->getLicenseUri());
-                $this->getConfig()->setData('summary', $this->getDescription());
+                $this->getConfig()->setData('summary', $this->getSummary());
                 $this->getConfig()->setData('description', $this->getDescription());
                 $this->getConfig()->setData('version', (string)Mage::getConfig()->getNode()->modules->$name->version);
                 $this->getConfig()->setData('stability', $this->getStability());
@@ -196,7 +196,23 @@ class Mage_Shell_Packager extends Mage_Shell_Abstract
      */
     public function getLicenseUri()
     {
+        if(isset($this->getComposerJson()->extra->magento_connect->license_uri)) {
+            return $this->getComposerJson()->extra->magento_connect->license_uri;
+        }
         return "http://www.spdx.org/licenses/" . $this->getLicense();
+    }
+
+    /**
+     * Get the summary for the project. Falls back to description if summary is not explicitly set.
+     * @return mixed
+     */
+    public function getSummary()
+    {
+        if(isset($this->getComposerJson()->extra->magento_connect->summary)) {
+            return $this->getComposerJson()->extra->magento_connect->summary;
+        }
+
+        return $this->getDescription();
     }
 
     /**


### PR DESCRIPTION
This change adds in support for the `license_uri` and `summary` fields
in the composer file, which match the appropriate locations in the
Magento Connect package.xml.
- `license_uri` is added to the <license> node, in place of the implicit
  use of the Software Package Data Exchange website. This allows for
  links directly to the original website for the license.
- `summary` sets the content for the <summary>
  
   node, rather than always
  taking the value from the `description` field.

These changes are optional, so if the fields are omitted then the
package file will be created as it is currently.
