### PR TITLE
Include package dependency contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Example
                         "type":"mage",
                         "structure":"file",
                         "path":"just a random file path"
+                    },
+                    {
+                        "type":"magelib",
+                        "structure":"dir",
+                        "path":"SomeNamespace",
+                        "from":"vendor/foo/bar/src/SomeNamespace"
                     }
                 ]
             }
@@ -137,6 +143,9 @@ It is very similar to modman but you need to tell magento the type, if it is a f
 
 
 `path` is the path to your source files.
+
+If you want to include an external library in your package, but on your machine it's located in another path (because
+it is a dependency installed via composer), you may specify the real path `from`.
 
 History
 =======

--- a/src/shell/packager.php
+++ b/src/shell/packager.php
@@ -191,6 +191,14 @@ class Mage_Shell_Packager extends Mage_Shell_Abstract
                 $ignore = $element->ignore;
             }
 
+            if(isset($element->from)) {
+                $mageTargets = new Mage_Connect_Package_Target();
+                $targetMap = $mageTargets->getTargets();
+
+                $link = BP . DS . $targetMap[$element->type] . DS . $element->path;
+                symlink(BP . DS . $element->from, $link);
+            }
+
             $contents["target"][$i] = $element->type;
             $contents["type"][$i] = $element->structure;
             $contents["path"][$i] = $element->path;


### PR DESCRIPTION
If a module depends on a library, that is installed via composer, it is difficult to embed it into your Magento extension automatically. I added a `from` key that allows inclusion of the dependency in the defined place.
To include it, the packager will just add a symlink at `path`, pointing to `from`, no further magic is required.
